### PR TITLE
Attempts to resolve T213488 without upgrading to Superset 0.28.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ gunicorn==19.8.0
 humanize==0.5.1
 idna==2.6
 markdown==2.6.11
-pandas==0.22.0
+pandas==0.23.1
 parsedatetime==2.0.0
 pathlib2==2.3.0
 polyline==1.3.2

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -1177,15 +1177,14 @@ class NVD3TimeSeriesViz(NVD3Viz):
 
         if rolling_type in ('mean', 'std', 'sum') and rolling_periods:
             kwargs = dict(
-                arg=df,
                 window=rolling_periods,
                 min_periods=min_periods)
             if rolling_type == 'mean':
-                df = pd.rolling_mean(**kwargs)
+                df = df.rolling(**kwargs).mean()
             elif rolling_type == 'std':
-                df = pd.rolling_std(**kwargs)
+                df = df.rolling(**kwargs).std()
             elif rolling_type == 'sum':
-                df = pd.rolling_sum(**kwargs)
+                df = df.rolling(**kwargs).sum()
         elif rolling_type == 'cumsum':
             df = df.cumsum()
         if min_periods:


### PR DESCRIPTION
Compare [this pull request](https://github.com/apache/incubator-superset/pull/5328/files) from the main Superset project.

Note this patch does seem to require Pandas version 0.23.1 (currently the requirement is 0.22) but maybe this is easier to pull off than upgrading Superset to 0.28.1? 

The commit this patch is modeled after ([6fee058](https://github.com/apache/incubator-superset/commit/6fee058)) is not very far ahead of its LCA with the WMF fork, and after a little plumbing it seems like it will probably work as a drop-in, since all that will be changing is that the new `pandas.rolling()` method will be available on the `pandas.DataFrame()` object after the upgrade to Pandas 0.23.1, and this patch will use that instead of the deprecated methods `pandas.rolling_mean()`, `pandas.rolling_std()` etc.