### PR TITLE
Attempts to resolve T213488 (compare commit 6fee058)

### DIFF
--- a/superset/viz.py
+++ b/superset/viz.py
@@ -1177,15 +1177,14 @@ class NVD3TimeSeriesViz(NVD3Viz):
 
         if rolling_type in ('mean', 'std', 'sum') and rolling_periods:
             kwargs = dict(
-                arg=df,
                 window=rolling_periods,
                 min_periods=min_periods)
             if rolling_type == 'mean':
-                df = pd.rolling_mean(**kwargs)
+                df = df.rolling(**kwargs).mean()
             elif rolling_type == 'std':
-                df = pd.rolling_std(**kwargs)
+                df = df.rolling(**kwargs).std()
             elif rolling_type == 'sum':
-                df = pd.rolling_sum(**kwargs)
+                df = df.rolling(**kwargs).sum()
         elif rolling_type == 'cumsum':
             df = df.cumsum()
         if min_periods:


### PR DESCRIPTION
Compare [this pull request](https://github.com/apache/incubator-superset/pull/5328/files) from the main Superset project.

Note the original patch seems to require Pandas version 0.23.1 (currently the requirement is 0.22) but it seems like Pandas 0.22.0 (which we currently run) already supports the necessary `pandas.rolling()` interface, and in fact the current bug in T213488 is Pandas complaining about _not_ having the deprecated interfaces, so they are apparently already gone in 0.22.0 anyway.

So this patch ought to work as a drop-in, since the only code it's changing is code that is currently broken anyway.